### PR TITLE
Include ModelicaUtilities.h as C

### DIFF
--- a/MessagePack/Resources/Include/msgpack-modelica.h
+++ b/MessagePack/Resources/Include/msgpack-modelica.h
@@ -50,7 +50,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <msgpack.h>
 #include <stdio.h>
 #include <errno.h>
+#if defined(__cplusplus)
+extern "C" {
+#endif
 #include <ModelicaUtilities.h>
+#if defined(__cplusplus)
+}
+#endif
 
 #if HAVE_MMAP
 #include <sys/types.h>


### PR DESCRIPTION
Otherwise the MSVC linker complains with

```
msgpack-modelica.obj : error LNK2019: unresolved external symbol "void __cdecl ModelicaFormatError(char const *,...)" (?ModelicaFormatError@@YAXPBDZZ) referenced in function _msgpack_modelica_sbuffer_to_file
msgpack-modelica.obj : error LNK2019: unresolved external symbol "void __cdecl ModelicaError(char const *)" (?ModelicaError@@YAXPBD@Z) referenced in function _msgpack_modelica_unpack_int
msgpack-modelica.obj : error LNK2019: unresolved external symbol "char * __cdecl ModelicaAllocateString(unsigned int)" (?ModelicaAllocateString@@YAPADI@Z) referenced in function _msgpack_modelica_unpack_string
```
