### PR TITLE
Fix pure C compilation of msgpack on Windows

### DIFF
--- a/MessagePack/Resources/Include/msgpack-modelica.h
+++ b/MessagePack/Resources/Include/msgpack-modelica.h
@@ -47,6 +47,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
+#if !defined(__cplusplus) && defined(_MSC_VER)
+#define bool int
+#define FALSE (0)
+#define TRUE (!FALSE)
+#define inline __inline
+#endif
+
 #include <msgpack.h>
 #include <stdio.h>
 #include <errno.h>


### PR DESCRIPTION
Compilation of msgpack-modelica.h fails using MSVC. This fix together with msgpack/msgpack-c#90 makes compilation successfull.
