### PR TITLE
Fix include path of msgpack-modelica.h

### DIFF
--- a/MessagePack/Resources/BuildProjects/VisualStudio2010/msgpack.vcxproj
+++ b/MessagePack/Resources/BuildProjects/VisualStudio2010/msgpack.vcxproj
@@ -152,7 +152,7 @@
     <CustomBuildStep />
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
@@ -184,7 +184,7 @@ copy unpack_template.h src\msgpack\unpack_template.h</Command>
     </CustomBuildStep>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -235,7 +235,7 @@ copy unpack_template.h src\msgpack\unpack_template.h</Command>
     </PreBuildEvent>
     <CustomBuildStep />
     <ClCompile>
-      <AdditionalIncludeDirectories>..;..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>
@@ -250,7 +250,7 @@ copy unpack_template.h src\msgpack\unpack_template.h</Command>
     <PreBuildEvent />
     <CustomBuildStep />
     <ClCompile>
-      <AdditionalIncludeDirectories>..;..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\C-Sources\msgpack-c\include</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <PrecompiledHeader>

--- a/MessagePack/Resources/Include/msgpack-modelica.h
+++ b/MessagePack/Resources/Include/msgpack-modelica.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-#include <../C-Sources/msgpack-c/include/msgpack.h>
+#include "../C-Sources/msgpack-c/include/msgpack.h"
 #include <stdio.h>
 #include <errno.h>
 #include <ModelicaUtilities.h>


### PR DESCRIPTION
Header msgpack-modelica.h requires that "modelica://MessagePack/Resources/Include" is on the include path. This is not the case for generated C code from tools like SimulationX which take "modelica://MessagePack/Resources/C-Sources/msgpack-c/include" as set by the IncludeDirectory annotation as include path.

This fixes the include error
```
c:\Projekte\msgpack-modelica\MessagePack\Resources\C-Sources\msgpack-c\include\../../../Include/msgpack-modelica.h(50) : fatal error C1083: Cannot open include file: '../C-Sources/msgpack-c/include/msgpack.h': No such file or directory
```
of generated C code from Dymola or SimulationX. It is necessary to only have one include directory (which is "modelica://MessagePack/Resources/C-Sources/msgpack-c/include") for the VS2010 build project and the generated C code from the simulation tools.