### PR TITLE
Define WIN32_LEAN_AND_MEAN before inclusion of Windows.h.

### DIFF
--- a/MessagePack/Resources/Include/msgpack-modelica.h
+++ b/MessagePack/Resources/Include/msgpack-modelica.h
@@ -61,7 +61,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #if defined(_WIN32)
-#include <Windows.h>
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
 #include <io.h>
 #endif
 


### PR DESCRIPTION
This excludes Win APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets and thus speeds up compilation.